### PR TITLE
573272907 requesting emails set to wrong user

### DIFF
--- a/app/helpers/transaction_helper.rb
+++ b/app/helpers/transaction_helper.rb
@@ -539,7 +539,7 @@ module TransactionHelper
 
   def transaction_starter(transaction:)
     transaction_type = transaction.listing.listing_shape.name
-    (transaction_type == 'requesting' && transaction.current_state != 'free') ? transaction.listing_author : transaction.starter
+    transaction_type == 'requesting' && transaction.current_state != 'free' ? transaction.listing_author : transaction.starter
   end
 
   def transaction_author(transaction:)

--- a/app/jobs/transaction_cancellation_dismissed_job.rb
+++ b/app/jobs/transaction_cancellation_dismissed_job.rb
@@ -11,8 +11,8 @@ class TransactionCancellationDismissedJob < Struct.new(:transaction_id, :communi
   end
 
   def perform
-    tx = Transaction.find(transaction_id)
-    TransactionMailer.transaction_cancellation_dismissed(transaction: tx, recipient: tx.author).deliver_now
-    TransactionMailer.transaction_cancellation_dismissed(transaction: tx, recipient: tx.starter).deliver_now
+    transaction = Transaction.find(transaction_id)
+    TransactionMailer.transaction_cancellation_dismissed(transaction: transaction, recipient: transaction.other_party(transaction.buyer)).deliver_now
+    TransactionMailer.transaction_cancellation_dismissed(transaction: transaction, recipient: transaction.buyer).deliver_now
   end
 end

--- a/app/jobs/transaction_confirmed_job.rb
+++ b/app/jobs/transaction_confirmed_job.rb
@@ -21,15 +21,5 @@ class TransactionConfirmedJob < Struct.new(:conversation_id, :community_id)
         MailCarrier.deliver_now(PersonMailer.transaction_confirmed(transaction, community, :buyer))
       end
     end
-
-    if transaction.payment_gateway == :stripe
-      payment = StripeService::Store::StripePayment.get(community_id, transaction.id)
-      default_available = APP_CONFIG.stripe_payout_delay.to_f.days.from_now
-      available_date = (payment[:available_on] || default_available) + 24.hours
-      case StripeService::API::Api.wrapper.charges_mode(community_id)
-      when :destination then Delayed::Job.enqueue(StripePayoutJob.new(transaction.id, community_id), :priority => 9, :run_at => available_date)
-      when :separate then Delayed::Job.enqueue(StripePayoutJob.new(transaction.id, community_id), :priority => 9)
-      end
-    end
   end
 end

--- a/app/jobs/transaction_disputed_job.rb
+++ b/app/jobs/transaction_disputed_job.rb
@@ -10,7 +10,7 @@ class TransactionDisputedJob < Struct.new(:transaction_id, :community_id)
     transaction = Transaction.find(transaction_id)
     community = Community.find(community_id)
     TransactionMailer.transaction_disputed(transaction: transaction,
-                                           recipient: transaction.seller,
+                                           recipient: transaction.other_party(transaction.buyer),
                                            is_seller: true).deliver_now
     TransactionMailer.transaction_disputed(transaction: transaction,
                                            recipient: transaction.buyer,

--- a/app/jobs/transaction_refunded_job.rb
+++ b/app/jobs/transaction_refunded_job.rb
@@ -11,8 +11,8 @@ class TransactionRefundedJob < Struct.new(:transaction_id, :community_id)
   end
 
   def perform
-    tx = Transaction.find(transaction_id)
-    TransactionMailer.transaction_refunded(transaction: tx, recipient: tx.author).deliver_now
-    TransactionMailer.transaction_refunded(transaction: tx, recipient: tx.starter).deliver_now
+    transaction = Transaction.find(transaction_id)
+    TransactionMailer.transaction_refunded(transaction: transaction, recipient: transaction.other_party(transaction.buyer)).deliver_now
+    TransactionMailer.transaction_refunded(transaction: transaction, recipient: transaction.buyer).deliver_now
   end
 end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -54,16 +54,16 @@ class PersonMailer < ActionMailer::Base
     end
   end
 
-  def transaction_confirmed(conversation, community, send_to = :seller)
+  def transaction_confirmed(transaction, community, send_to = :seller)
     @email_type =  "email_about_completed_transactions"
-    @conversation = conversation
+    @transaction = transaction
     @recipient_is_seller = send_to == :seller
-    recipient = @recipient_is_seller ? conversation.seller : conversation.buyer
+    recipient = @recipient_is_seller ? transaction.seller : transaction.buyer
     set_up_layout_variables(recipient, community, @email_type)
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
       mail(:to => recipient.confirmed_notification_emails_to,
            :from => community_specific_sender(community),
-           :subject => t("emails.transaction_confirmed.request_marked_as_#{@conversation.status}")) do |format|
+           :subject => t("emails.transaction_confirmed.request_marked_as_#{@transaction.status}")) do |format|
         format.html { render v2_template(community.id, 'transaction_confirmed'), layout: v2_layout(community.id) }
       end
     end

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -21,7 +21,9 @@ class PersonMailer < ActionMailer::Base
 
   def conversation_status_changed(transaction, community)
     @email_type =  (transaction.status == "accepted" ? "email_when_conversation_accepted" : "email_when_conversation_rejected")
-    recipient = transaction.other_party(transaction.listing.author)
+    recipient = transaction.buyer
+    @other_party = transaction.listing.listing_shape.name == 'requesting' ? transaction.listing_author : transaction.author
+
     set_up_layout_variables(recipient, community, @email_type)
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
       @transaction = transaction

--- a/app/mailers/person_mailer.rb
+++ b/app/mailers/person_mailer.rb
@@ -58,7 +58,11 @@ class PersonMailer < ActionMailer::Base
     @email_type =  "email_about_completed_transactions"
     @transaction = transaction
     @recipient_is_seller = send_to == :seller
-    recipient = @recipient_is_seller ? transaction.seller : transaction.buyer
+    recipient = if @recipient_is_seller
+      @transaction.listing.listing_shape.name == 'requesting' ? transaction.listing_author : transaction.seller
+    else
+      transaction.buyer
+    end
     set_up_layout_variables(recipient, community, @email_type)
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do
       mail(:to => recipient.confirmed_notification_emails_to,

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -23,10 +23,10 @@ class TransactionMailer < ActionMailer::Base
     @transaction = transaction
     @community = transaction.community
 
-    recipient = if @transaction.listing.listing_shape.name == 'requesting'
-        transaction.listing_author
-      else
-        transaction.author
+    recipient = if transaction.listing.listing_shape.name == 'requesting'
+      transaction.listing_author
+    else
+      transaction.author
     end
 
     set_up_layout_variables(recipient, transaction.community)

--- a/app/mailers/transaction_mailer.rb
+++ b/app/mailers/transaction_mailer.rb
@@ -228,7 +228,7 @@ class TransactionMailer < ActionMailer::Base
 
   def transaction_refunded(transaction:, recipient:)
     @transaction = transaction
-    @is_seller = transaction.author == recipient
+    @is_seller = (recipient == transaction.other_party(transaction.buyer))
     community = transaction.community
     set_up_layout_variables(recipient, community)
     with_locale(recipient.locale, community.locales.map(&:to_sym), community.id) do

--- a/app/views/person_mailer/automatic_confirmation/transaction_automatically_confirmed-v2.html.haml
+++ b/app/views/person_mailer/automatic_confirmation/transaction_automatically_confirmed-v2.html.haml
@@ -5,8 +5,8 @@
 %tr
   %td.email-content
     %p.text-bold
-      = t("emails.transaction_automatically_confirmed_v2.we_have_marked_request_as_confirmed", :request => @conversation.listing.title)
+      = t("emails.transaction_automatically_confirmed_v2.we_have_marked_request_as_confirmed", :request => @transaction.listing.title)
     %p
-      = t("emails.transaction_automatically_confirmed_v2.order_automatically_confirmed", :days_passed => @conversation.automatic_confirmation_after_days)
+      = t("emails.transaction_automatically_confirmed_v2.order_automatically_confirmed", :days_passed => @transaction.automatic_confirmation_after_days)
 
-= render partial: "person_mailer/automatic_confirmation/automatically_confirmed_footer-v2", :locals => { transaction: @conversation, recipient: @recipient, url_params: @url_params }
+= render partial: "person_mailer/automatic_confirmation/automatically_confirmed_footer-v2", :locals => { transaction: @transaction, recipient: @recipient, url_params: @url_params }

--- a/app/views/person_mailer/automatic_confirmation/transaction_automatically_confirmed.html.haml
+++ b/app/views/person_mailer/automatic_confirmation/transaction_automatically_confirmed.html.haml
@@ -1,6 +1,6 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.transaction_automatically_confirmed.we_have_marked_request_as_confirmed", :request => @conversation.listing.title, :days_passed => @conversation.automatic_confirmation_after_days)
+      = t("emails.transaction_automatically_confirmed.we_have_marked_request_as_confirmed", :request => @transaction.listing.title, :days_passed => @transaction.automatic_confirmation_after_days)
 
-= render partial: "person_mailer/automatic_confirmation/automatically_confirmed_footer", :locals => { transaction: @conversation, recipient: @recipient, url_params: @url_params }
+= render partial: "person_mailer/automatic_confirmation/automatically_confirmed_footer", :locals => { transaction: @transaction, recipient: @recipient, url_params: @url_params }

--- a/app/views/person_mailer/confirm_reminder-v2.html.haml
+++ b/app/views/person_mailer/confirm_reminder-v2.html.haml
@@ -1,21 +1,21 @@
-- conversation_url = person_message_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
-- confirm_url = confirm_person_message_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
-- cancel_url = cancel_person_message_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
+- transaction_url = person_message_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
+- confirm_url = confirm_person_message_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
+- cancel_url = cancel_person_message_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
 
 %tr
   %td.person-name
     %h1
-      = t("emails.common.hi", name: PersonViewUtils.person_display_name_for_type(@conversation.buyer, "first_name_only"))
-      = t("emails.confirm_reminder_v2.headline", :request_link => link_to(@conversation.listing_title, conversation_url)).html_safe
+      = t("emails.common.hi", name: PersonViewUtils.person_display_name_for_type(@transaction.buyer, "first_name_only"))
+      = t("emails.confirm_reminder_v2.headline", :request_link => link_to(@transaction.listing_title, transaction_url)).html_safe
 %tr
   %td.email-content
     %p.text-bold
-      = t("emails.confirm_reminder_v2.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@conversation.created_at.to_date), :other_party_full_name => @conversation.seller.name(@conversation.community), :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.seller, "first_name_only")).html_safe
+      = t("emails.confirm_reminder_v2.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@transaction.created_at.to_date), :other_party_full_name => @transaction.seller.name(@transaction.community), :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.seller, "first_name_only")).html_safe
 
     %p
       = t("emails.confirm_reminder.if_will_not_happen_you_should_cancel", :cancel_it_link => link_to(t("emails.confirm_reminder.cancel_it_link_text"), cancel_url)).html_safe
     %p
-      = t("emails.confirm_reminder.automatic_confirmation", :days_to_automatic_confirmation => @conversation.automatic_confirmation_after_days).html_safe
+      = t("emails.confirm_reminder.automatic_confirmation", :days_to_automatic_confirmation => @transaction.automatic_confirmation_after_days).html_safe
 
 = render :partial => "action_button-v2", :locals => { :text => t("conversations.status_link.confirm"), :url => confirm_url}
 

--- a/app/views/person_mailer/confirm_reminder.html.haml
+++ b/app/views/person_mailer/confirm_reminder.html.haml
@@ -1,11 +1,11 @@
-- conversation_url = person_message_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
-- confirm_url = confirm_person_message_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
-- cancel_url = cancel_person_message_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
+- transaction_url = person_message_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
+- confirm_url = confirm_person_message_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
+- cancel_url = cancel_person_message_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
 
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@conversation.created_at.to_date), :request_link => link_to(@conversation.listing_title, conversation_url), :other_party_full_name => @conversation.seller.name(@conversation.community), :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.seller, "first_name_only")).html_safe
+      = t("emails.confirm_reminder.you_have_not_yet_confirmed_or_canceled_request", :date => time_ago(@transaction.created_at.to_date), :request_link => link_to(@transaction.listing_title, transaction_url), :other_party_full_name => @transaction.seller.name(@transaction.community), :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only")).html_safe
 
 %tr
   %td{:align => "left", :style => "padding-top: 25px; padding-bottom: 25px;"}
@@ -19,4 +19,4 @@
 %tr
   %td{:align => "left", :style => "padding-bottom: 25px;"}
     %font{body_font}
-      = t("emails.confirm_reminder.automatic_confirmation", :days_to_automatic_confirmation => @conversation.automatic_confirmation_after_days).html_safe
+      = t("emails.confirm_reminder.automatic_confirmation", :days_to_automatic_confirmation => @transaction.automatic_confirmation_after_days).html_safe

--- a/app/views/person_mailer/conversation_status_changed.html.haml
+++ b/app/views/person_mailer/conversation_status_changed.html.haml
@@ -6,7 +6,7 @@
 %tr
   %td{:align => "left"}
     %font{body_font}
-      = t("emails.conversation_status_changed.has_#{@transaction.status}_your_request", :accepter => PersonViewUtils.person_display_name(@transaction.listing.author, @current_community), :listing => @transaction.listing_title)
+      = t("emails.conversation_status_changed.has_#{@transaction.status}_your_request", :accepter => PersonViewUtils.person_display_name(@other_party, @current_community), :listing => @transaction.listing_title)
       = additional_text
 
 -# TODO: Should we link transition to message?
@@ -15,7 +15,7 @@
   %tr
     %td{:align => "left", :style => "padding-top: 15px;"}
       %font{body_font}
-        = t("emails.transaction_confirmed.here_is_a_message_from", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only"))
+        = t("emails.transaction_confirmed.here_is_a_message_from", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@other_party, "first_name_only"))
   = render :partial => "quote", :locals => { :quote => @transaction.conversation.last_message.content }
 
 = render :partial => "action_button", :locals => { :text => action_text, :url => action_url}

--- a/app/views/person_mailer/transaction_confirmed-v2.html.haml
+++ b/app/views/person_mailer/transaction_confirmed-v2.html.haml
@@ -1,27 +1,27 @@
-- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
-- url = new_person_message_feedback_url(@recipient, @url_params.merge({:message_id => @conversation.id.to_s}))
+- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
+- url = new_person_message_feedback_url(@recipient, @url_params.merge({:message_id => @transaction.id.to_s}))
 
 %tr
   %td.person-name
     - recipient_name = PersonViewUtils.person_display_name_for_type(@recipient, 'first_name_only')
-    - listing_link = link_to @conversation.listing.title, listing_url(@url_params.merge(id: @conversation.listing_id))
-    - stripe_confirmed = @conversation.payment_gateway == :stripe && @conversation.status == 'confirmed'
-    - if @conversation.last_transition_by_admin?
+    - listing_link = link_to @transaction.listing.title, listing_url(@url_params.merge(id: @transaction.listing_id))
+    - stripe_confirmed = @transaction.payment_gateway == :stripe && @transaction.status == 'confirmed'
+    - if @transaction.last_transition_by_admin?
       - other_party_full_name = t('emails.transaction_confirmed.team_title')
     - else
-      - other_party_full_name = PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only")
+      - other_party_full_name = PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only")
     %h1
       = t("emails.common.hi", name: recipient_name)
-      = t("emails.transaction_confirmed_v2.headline_#{@conversation.status}", other_party_full_name: other_party_full_name, listing_link: listing_link).html_safe
+      = t("emails.transaction_confirmed_v2.headline_#{@transaction.status}", other_party_full_name: other_party_full_name, listing_link: listing_link).html_safe
 
 %tr
   %td.email-content
     %p.text-bold
       - if stripe_confirmed && @recipient_is_seller
-        = t("emails.transaction_confirmed_v2.stripe.has_marked_request_as_confirmed", :request => @conversation.listing.title)
-      = t("emails.transaction_confirmed_v2.can_give_feedback", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only"))
+        = t("emails.transaction_confirmed_v2.stripe.has_marked_request_as_confirmed", :request => @transaction.listing.title)
+      = t("emails.transaction_confirmed_v2.can_give_feedback", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only"))
 
     %p
-      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only"))
+      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only"))
 
-= render :partial => "action_button-v2", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only")), :url => url}
+= render :partial => "action_button-v2", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only")), :url => url}

--- a/app/views/person_mailer/transaction_confirmed.html.haml
+++ b/app/views/person_mailer/transaction_confirmed.html.haml
@@ -1,25 +1,25 @@
-- conversation_url = person_transaction_url(@recipient, @url_params.merge({:id => @conversation.id.to_s}))
-- url = new_person_message_feedback_url(@recipient, @url_params.merge({:message_id => @conversation.id.to_s}))
+- transaction_url = person_transaction_url(@recipient, @url_params.merge({:id => @transaction.id.to_s}))
+- url = new_person_message_feedback_url(@recipient, @url_params.merge({:message_id => @transaction.id.to_s}))
 
 %tr
   %td{:align => "left"}
     %font{body_font}
-      - stripe_confirmed = @conversation.payment_gateway == :stripe && @conversation.status == 'confirmed'
-      - key = stripe_confirmed && @recipient_is_seller ? 'emails.transaction_confirmed.stripe.has_marked_request_as_confirmed' : "emails.transaction_confirmed.has_marked_request_as_#{@conversation.status}"
-      - if @conversation.last_transition_by_admin?
+      - stripe_confirmed = @transaction.payment_gateway == :stripe && @transaction.status == 'confirmed'
+      - key = stripe_confirmed && @recipient_is_seller ? 'emails.transaction_confirmed.stripe.has_marked_request_as_confirmed' : "emails.transaction_confirmed.has_marked_request_as_#{@transaction.status}"
+      - if @transaction.last_transition_by_admin?
         - other_party_full_name = t('emails.transaction_confirmed.team_title')
       - else
-        - other_party_full_name = PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only")
-      = t(key, :other_party_full_name => other_party_full_name, :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only"), :request => @conversation.listing.title)
+        - other_party_full_name = PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only")
+      = t(key, :other_party_full_name => other_party_full_name, :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only"), :request => @transaction.listing.title)
 
 %tr
   %td{:align => "left", :style => "padding-top: 15px;"}
     %font{body_font}
-      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only"))
+      = t("emails.transaction_confirmed.giving_feedback_is_good_idea", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only"))
 
-= render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@conversation.other_party(@recipient), "first_name_only")), :url => url}
+= render :partial => "action_button", :locals => { :text => t("emails.transaction_confirmed.give_feedback_to", :other_party_given_name => PersonViewUtils.person_display_name_for_type(@transaction.other_party(@recipient), "first_name_only")), :url => url}
 
 %tr
   %td{:align => "left", :style => "padding-bottom: 25px;"}
     %font{body_font}
-      = link_to t("emails.accept_reminder.show_thread"), conversation_url
+      = link_to t("emails.accept_reminder.show_thread"), transaction_url

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,11 +82,9 @@ Rails.application.configure do
 
   if APP_CONFIG.mail_delivery_method == "letter_opener"
     ActionMailer::Base.delivery_method = :letter_opener
-    ActionMailer::Base..perform_deliveries = true
+    ActionMailer::Base.perform_deliveries = true
     LetterOpener.configure do |config|
-      # To render only the message body, without any metadata or extra containers or styling.
-      # Default value is `:default` that renders styled message with showing useful metadata.
-      config.message_template = :light
+      config.message_template = :default
     end
   elsif APP_CONFIG.mail_delivery_method == "sendmail"
     ActionMailer::Base.delivery_method = :sendmail

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1672,7 +1672,7 @@ en:
       headline: "you have a message!"
       reply: "Click here to reply to %{sender}"
     new_payment:
-      new_payment: 'A new payment has been made'
+      new_payment: 'A new payment has been made on %{service_name}'
       price_per_unit_type: 'Price per %{unit_type}'
       quantity: 'Quantity:'
       you_have_received_new_payment: 'The amount of <b>%{payment_sum}</b> has been paid for <b>%{listing_title}</b> by %{payer_full_name}. The money will be donated to the chosen causes. Here is your receipt.'
@@ -1686,7 +1686,7 @@ en:
       service_fee: '%{service_name} service fee:'
       buyer_service_fee: '%{service_name} service fee:'
       you_will_get: 'Total:'
-      new_payment: 'A new payment has been made'
+      new_payment: 'A new payment has been made on %{service_name}'
       price_per_unit_type: 'Price per %{unit_type}'
       quantity: 'Quantity:'
       you_have_received_new_payment: 'The amount of <b>%{payment_sum}</b> has been paid for <b>%{listing_title}</b> by %{payer_full_name}. The money will be donated to the chosen causes. Here is your receipt.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1672,10 +1672,10 @@ en:
       headline: "you have a message!"
       reply: "Click here to reply to %{sender}"
     new_payment:
-      new_payment: 'You have received a new payment'
+      new_payment: 'A new payment has been made'
       price_per_unit_type: 'Price per %{unit_type}'
       quantity: 'Quantity:'
-      you_have_received_new_payment: 'You have been paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> by %{payer_full_name}. Here is your receipt.'
+      you_have_received_new_payment: 'The amount of <b>%{payment_sum}</b> has been paid for <b>%{listing_title}</b> by %{payer_full_name}. The money will be donated to the chosen causes. Here is your receipt.'
       listing_per_unit_title: '%{title}, per %{unit_type}'
     payment_receipt_to_seller:
       payment_gateway_fee: 'Payment processing fee:'
@@ -1686,19 +1686,19 @@ en:
       service_fee: '%{service_name} service fee:'
       buyer_service_fee: '%{service_name} service fee:'
       you_will_get: 'Total:'
-      new_payment: 'You have received a new payment'
+      new_payment: 'A new payment has been made'
       price_per_unit_type: 'Price per %{unit_type}'
       quantity: 'Quantity:'
-      you_have_received_new_payment: 'You have been paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> by %{payer_full_name}. Here is your receipt.'
+      you_have_received_new_payment: 'The amount of <b>%{payment_sum}</b> has been paid for <b>%{listing_title}</b> by %{payer_full_name}. The money will be donated to the chosen causes. Here is your receipt.'
       stripe:
-        you_have_received_new_payment: 'The amount of <b>%{payment_sum}</b> has been paid for <b>%{listing_title}</b> by %{payer_full_name}. The money is being held by %{service_name} until the order is marked as completed. Here is your receipt.'
+        you_have_received_new_payment: 'The amount of <b>%{payment_sum}</b> has been paid for <b>%{listing_title}</b> by %{payer_full_name}. The money is being held by %{service_name} and will be donated to the chosen causes the order is marked as completed. Here is your receipt.'
     payment_receipt_to_seller_v2:
       headline: 'you have been paid %{payment_sum} for %{listing_link} by %{payer_name}.'
       main_text_stripe: 'The money is being held by %{service_name} until the order is marked as completed.'
       price_breakdown: 'Price breakdown'
     payment_receipt_to_payer:
       receipt_of_payment: 'Receipt of payment'
-      you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> to %{recipient_full_name}. Here is a receipt of the payment.'
+      you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> on %{service_name}. Here is a receipt of the payment.'
       product: Product
       price_per_unit_type: 'Price per %{unit_type}'
       duration: Duration
@@ -1713,7 +1713,7 @@ en:
       money_will_be_transferred: 'The money will be transferred to %{recipient_name} when a) you have marked the request completed or b) %{automatic_confirmation_days} days have passed since you paid.'
     payment_receipt_to_payer_v2:
       headline: 'here is your receipt for %{listing_link}.'
-      you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b>.'
+      you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> on %{service_name}.'
     paypal_new_payment:
       paypal_gateway_fee: "PayPal's fee:"
       shipping_total: 'Shipping:'
@@ -1724,7 +1724,7 @@ en:
       you_will_get: 'Total:'
     receipt_to_payer:
       receipt_of_payment: 'Receipt of payment'
-      you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> to %{recipient_full_name}. Here is a receipt of the payment.'
+      you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b> on %{service_name}. The money will be donated to the chosen causes. Here is a receipt of the payment.'
       product: Product
       price_per_unit_type: 'Price per %{unit_type}'
       duration: Duration
@@ -1735,7 +1735,7 @@ en:
       buyer_service_fee: '%{service_name} service fee'
       stripe_gateway_fee: "Stripe's fee:"
       paypal_gateway_fee: "PayPal's fee:"
-      money_will_be_transferred: 'The money will be transferred to %{recipient_name} when a) you have marked the request completed or b) %{automatic_confirmation_days} days have passed since you paid.'
+      money_will_be_transferred: 'The money will be transferred to the chosen causes when a) you have marked the request completed or b) %{automatic_confirmation_days} days have passed since you paid.'
       listing_per_unit_title: '%{title}, per %{unit_type}'
       stripe:
         you_have_made_new_payment: 'You have paid <b>%{payment_sum}</b> for <b>%{listing_title}</b>. The money is being held by %{service_name} and will be donated to the chosen causes once you mark the order as completed. Here is a receipt of the payment.'

--- a/spec/controllers/admin/community_transactions_controller_spec.rb
+++ b/spec/controllers/admin/community_transactions_controller_spec.rb
@@ -243,10 +243,9 @@ describe Admin::CommunityTransactionsController, type: :controller do
       expect(email_to_buyer.to.include?(buyer.confirmed_notification_emails_to)).to eq true
       expect(email_to_buyer.subject).to eq 'Order dispute dismissed - The Sharetribe team has rejected the dispute from Proto T'
 
-      expect(Delayed::Job.count).to eq 3
+      expect(Delayed::Job.count).to eq 2
       handlers = Delayed::Job.all.map(&:handler)
       expect(handlers.select{|x| x.match 'TestimonialReminderJob'}.size).to eq 2
-      expect(handlers.select{|x| x.match 'StripePayoutJob'}.size).to eq 1
     end
   end
 end

--- a/spec/controllers/admin2/transactions_reviews/manage_transactions_controller_spec.rb
+++ b/spec/controllers/admin2/transactions_reviews/manage_transactions_controller_spec.rb
@@ -243,10 +243,9 @@ describe Admin2::TransactionsReviews::ManageTransactionsController, type: :contr
       expect(email_to_buyer.to.include?(buyer.confirmed_notification_emails_to)).to eq true
       expect(email_to_buyer.subject).to eq 'Order dispute dismissed - The Sharetribe team has rejected the dispute from Proto T'
 
-      expect(Delayed::Job.count).to eq 3
+      expect(Delayed::Job.count).to eq 2
       handlers = Delayed::Job.all.map(&:handler)
       expect(handlers.select{|x| x.match 'TestimonialReminderJob'}.size).to eq 2
-      expect(handlers.select{|x| x.match 'StripePayoutJob'}.size).to eq 1
     end
   end
 end

--- a/spec/mailers/person_mailer_spec.rb
+++ b/spec/mailers/person_mailer_spec.rb
@@ -57,7 +57,8 @@ describe PersonMailer, type: :mailer do
   describe "status changed" do
 
     let(:author) { FactoryGirl.build(:person) }
-    let(:listing) { FactoryGirl.build(:listing, author: author, listing_shape_id: 123) }
+    let(:listing_shape) { FactoryGirl.build(:listing_shape) }
+    let(:listing) { FactoryGirl.build(:listing, author: author, listing_shape: listing_shape) }
     let(:starter) { FactoryGirl.build(:person, given_name: "Teppo", family_name: "Testaaja") }
     let(:conversation) { FactoryGirl.build(:conversation) }
     let(:transaction) { FactoryGirl.create(:transaction, listing: listing, starter: starter, conversation: conversation) }

--- a/spec/mailers/transaction_mailer_spec.rb
+++ b/spec/mailers/transaction_mailer_spec.rb
@@ -105,14 +105,14 @@ describe TransactionMailer, type: :mailer do
     describe '#payment_receipt_to_seller' do
       it 'works with default payment gateway' do
         email = TransactionMailer.payment_receipt_to_seller(paypal_transaction)
-        expect(email.body).to have_text('You have been paid €5 for Sledgehammer by Proto. Here is your receipt.')
+        expect(email.body).to have_text('The amount of €5 has been paid for Sledgehammer by Proto. The money will be donated to the chosen causes. Here is your receipt.')
         expect(email.body).to have_text("Price Proto paid: €5", normalize_ws: true)
         expect(email.body).to have_text('Payment processing fee: -€1.50', normalize_ws: true)
       end
 
       it 'works with default payment gateway per hour' do
         email = TransactionMailer.payment_receipt_to_seller(paypal_transaction_per_hour)
-        expect(email.body).to have_text('You have been paid €15 for Sledgehammer, per hour by Proto. Here is your receipt.')
+        expect(email.body).to have_text('The amount of €15 has been paid for Sledgehammer, per hour by Proto. The money will be donated to the chosen causes. Here is your receipt.')
         expect(email.body).to have_text('Price per hour €5', normalize_ws: true)
         expect(email.body).to have_text('Duration 3', normalize_ws: true)
         expect(email.body).to have_text('Price Proto paid: €15', normalize_ws: true)
@@ -121,13 +121,13 @@ describe TransactionMailer, type: :mailer do
 
       it 'works with stripe payment gateway' do
         email = TransactionMailer.payment_receipt_to_seller(stripe_transaction)
-        expect(email.body).to have_text('The amount of €2 has been paid for Sledgehammer by Proto. The money is being held by Sharetribe until the order is marked as completed. Here is your receipt.')
+        expect(email.body).to have_text('The amount of €2 has been paid for Sledgehammer by Proto. The money is being held by Sharetribe and will be donated to the chosen causes the order is marked as completed. Here is your receipt.')
         expect(email.body).to have_text('Price Proto paid: €2', normalize_ws: true)
       end
 
       it 'works with stripe payment gateway per hour' do
         email = TransactionMailer.payment_receipt_to_seller(stripe_transaction_per_hour)
-        expect(email.body).to have_text('The amount of €6 has been paid for Sledgehammer, per hour by Proto. The money is being held by Sharetribe until the order is marked as completed. Here is your receipt.')
+        expect(email.body).to have_text('The amount of €6 has been paid for Sledgehammer, per hour by Proto. The money is being held by Sharetribe and will be donated to the chosen causes the order is marked as completed. Here is your receipt.')
         expect(email.body).to have_text('Price per hour €2', normalize_ws: true)
         expect(email.body).to have_text('Duration 3', normalize_ws: true)
         expect(email.body).to have_text('Price Proto paid: €6', normalize_ws: true)
@@ -136,25 +136,25 @@ describe TransactionMailer, type: :mailer do
       describe 'without buyer commission' do
         it 'works with default payment gateway' do
           email = TransactionMailer.payment_receipt_to_seller(paypal_transaction)
-          expect(email.body).to have_text('You have been paid €5 for Sledgehammer by Proto. Here is your receipt.')
+          expect(email.body).to have_text('The amount of €5 has been paid for Sledgehammer by Proto. The money will be donated to the chosen causes. Here is your receipt.')
         end
 
         it 'works with stripe payment gateway' do
           email = TransactionMailer.payment_receipt_to_seller(stripe_transaction)
-          expect(email.body).to have_text('The amount of €2 has been paid for Sledgehammer by Proto. The money is being held by Sharetribe until the order is marked as completed. Here is your receipt.')
+          expect(email.body).to have_text('The amount of €2 has been paid for Sledgehammer by Proto. The money is being held by Sharetribe and will be donated to the chosen causes the order is marked as completed. Here is your receipt.')
         end
       end
 
       describe 'with buyer commission' do
         it 'works with stripe payment gateway' do
           email = TransactionMailer.payment_receipt_to_seller(stripe_transaction_with_buyer_commission)
-          expect(email.body).to have_text('The amount of €102 has been paid for Sledgehammer by Proto. The money is being held by Sharetribe until the order is marked as completed. Here is your receipt.')
+          expect(email.body).to have_text('The amount of €102 has been paid for Sledgehammer by Proto. The money is being held by Sharetribe and will be donated to the chosen causes the order is marked as completed. Here is your receipt.')
           expect(email.body).to have_text('Subtotal: €102', normalize_ws: true)
         end
 
         it 'works with stripe payment gateway per hour with shipping' do
           email = TransactionMailer.payment_receipt_to_seller(stripe_transaction_per_hour_with_shipping_with_buyer_commission)
-          expect(email.body).to have_text('The amount of €9 has been paid for Sledgehammer, per hour by Proto. The money is being held by Sharetribe until the order is marked as completed. Here is your receipt.')
+          expect(email.body).to have_text('The amount of €9 has been paid for Sledgehammer, per hour by Proto. The money is being held by Sharetribe and will be donated to the chosen causes the order is marked as completed. Here is your receipt.')
           expect(email.body).to have_text('Price per hour €2', normalize_ws: true)
           expect(email.body).to have_text('Duration 3', normalize_ws: true)
           expect(email.body).to have_text('Subtotal: €6', normalize_ws: true)
@@ -166,14 +166,14 @@ describe TransactionMailer, type: :mailer do
     describe '#payment_receipt_to_buyer' do
       it 'works with default payment gateway' do
         email = TransactionMailer.payment_receipt_to_buyer(paypal_transaction)
-        expect(email.body).to have_text('You have paid €5 for Sledgehammer to Joan. Here is a receipt of the payment.')
+        expect(email.body).to have_text('You have paid €5 for Sledgehammer on Sharetribe. The money will be donated to the chosen causes. Here is a receipt of the payment.')
         expect(email.body).to have_text('Subtotal €5', normalize_ws: true)
         expect(email.body).to have_text('Total €5', normalize_ws: true)
       end
 
       it 'works with default payment gateway per hour' do
         email = TransactionMailer.payment_receipt_to_buyer(paypal_transaction_per_hour)
-        expect(email.body).to have_text('You have paid €15 for Sledgehammer, per hour to Joan. Here is a receipt of the payment.')
+        expect(email.body).to have_text('You have paid €15 for Sledgehammer, per hour on Sharetribe. The money will be donated to the chosen causes. Here is a receipt of the payment.')
         expect(email.body).to have_text('Price per hour €5', normalize_ws: true)
         expect(email.body).to have_text('Duration 3', normalize_ws: true)
         expect(email.body).to have_text('Subtotal €15', normalize_ws: true)
@@ -199,7 +199,7 @@ describe TransactionMailer, type: :mailer do
       describe 'without buyer commission' do
         it 'works with default payment gateway' do
           email = TransactionMailer.payment_receipt_to_buyer(paypal_transaction)
-          expect(email.body).to have_text('You have paid €5 for Sledgehammer to Joan. Here is a receipt of the payment.')
+          expect(email.body).to have_text('You have paid €5 for Sledgehammer on Sharetribe. The money will be donated to the chosen causes. Here is a receipt of the payment.')
         end
 
         it 'works with stripe payment gateway' do


### PR DESCRIPTION
**Task:** https://www.wrike.com/open.htm?id=573272907
**Issue:** Requesting payment flow emails being sent to wrong users
**Changes:**

- TransactionConfirmedJob - Confirmed transaction email goes to the wrong user, author confirms transaction and gets the transaction confirmed email with opposite details of event
- TransactionStatusChangedJob - other party cancels transaction email goes to the wrong user (other party)
- ConfirmReminderJob - Email going to wrong user (requester)
- TransactionDisputedJob - ensure both users emailed
- TransactionRefundedJob - ensure both users emailed
- TransactionCancellationDismissedJob - emails to wrong user
- TransactionRefundedJob - refund notice to wrong user

**Deploy:**
- restart application server
- restart job worker