### PR TITLE
298722399 landing page redirect

### DIFF
--- a/app/controllers/homepage_controller.rb
+++ b/app/controllers/homepage_controller.rb
@@ -11,8 +11,6 @@ class HomepageController < ApplicationController
   def index
     params = unsafe_params_hash.select{|k, v| v.present? }
 
-    return redirect_to(landing_page_path) unless @current_user || session[:landing_page_visited]
-
     redirect_to sharetribe_landing_page_path and return if no_current_user_in_private_clp_enabled_marketplace?
 
     all_shapes = @current_community.shapes

--- a/app/controllers/marketplace_landing_page_controller.rb
+++ b/app/controllers/marketplace_landing_page_controller.rb
@@ -1,10 +1,17 @@
 class MarketplaceLandingPageController < ApplicationController
+  before_action :redirect_logged_in_users
+
   def show
-    session[:landing_page_visited] = true
     @is_landing_page = true
     requesting_listing_shape = ListingShape.exist.find_by(name: 'requesting')
     @requesting_listings = requesting_listing_shape&.listings_with_images(count: 3)
     offering_listing_shape = ListingShape.exist.find_by(name: 'offering')
     @offering_listings = offering_listing_shape&.listings_with_images(count: 3)
+  end
+
+  private
+
+  def redirect_logged_in_users
+    redirect_to(homepage_without_locale_path(locale: nil)) if @current_user
   end
 end

--- a/app/controllers/marketplace_landing_page_controller.rb
+++ b/app/controllers/marketplace_landing_page_controller.rb
@@ -3,8 +3,8 @@ class MarketplaceLandingPageController < ApplicationController
     session[:landing_page_visited] = true
     @is_landing_page = true
     requesting_listing_shape = ListingShape.exist.find_by(name: 'requesting')
-    @requesting_listings = requesting_listing_shape.listings_with_images(count: 3)
+    @requesting_listings = requesting_listing_shape&.listings_with_images(count: 3)
     offering_listing_shape = ListingShape.exist.find_by(name: 'offering')
-    @offering_listings = offering_listing_shape.listings_with_images(count: 3)
+    @offering_listings = offering_listing_shape&.listings_with_images(count: 3)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -812,9 +812,5 @@ module ApplicationHelper
   def social_link_placeholder(provider)
     SOCIAL_LINKS[provider.to_sym][:placeholder]
   end
-
-  def marketpace_or_landing_page_path_helper
-    @current_user ? homepage_without_locale_path : landing_page_path
-  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/helpers/marketplace_landing_page_helper.rb
+++ b/app/helpers/marketplace_landing_page_helper.rb
@@ -15,6 +15,7 @@ module MarketplaceLandingPageHelper
 
 
   def collect_card_attributes(listings_collection:, type:)
+    listings_collection ||= []
     listings_collection.map do |listing|
       {
         imageSrc: image_url(listing.listing_images.first.image.url(:square)),

--- a/app/view_utils/path_helpers.rb
+++ b/app/view_utils/path_helpers.rb
@@ -57,9 +57,9 @@ module PathHelpers
     when matches([true, __, __])
       paths.landing_page_without_locale_path(locale: nil)
     when matches([false, false, non_default_locale])
-      paths.homepage_with_locale_path(locale: locale_param)
+      paths.root_path(locale: locale_param)
     else
-      paths.homepage_without_locale_path(locale: nil)
+      paths.root_path(locale: nil)
     end
   end
 

--- a/app/views/layouts/_footer.haml
+++ b/app/views/layouts/_footer.haml
@@ -5,13 +5,13 @@
       %div{:class => "footer__links-container#{@custom_footer.container_modifier}"}
         %ul.footer__link-list
           %li.footer__link-list-item
-            %a.footer__link{:href => marketpace_or_landing_page_path_helper}
+            %a.footer__link{:href => root_path(locale: nil)}
               = t('footer.home')
           %li.footer__link-list-item
             %a.footer__link{:href => about_infos_path}
               = t('footer.about')
           %li.footer__link-list-item
-            %a.footer__link{:href => homepage_without_locale_path}
+            %a.footer__link{:href => homepage_without_locale_path(locale: nil)}
               = t('footer.marketplace')
           %li.footer__link-list-item
             %a.footer__link{:href => causes_infos_path}

--- a/app/views/layouts/_global_header.haml
+++ b/app/views/layouts/_global_header.haml
@@ -24,7 +24,7 @@
                 = locale_change_link[:title]
 
     .header-right.visible-tablet
-      = link_to homepage_without_locale_path, class: "header-text-link header-hover", id: "header-marketplace-link" do
+      = link_to homepage_without_locale_path(locale: nil), class: "header-text-link header-hover", id: "header-marketplace-link" do
         = t("header.marketplace")
 
     - unless logged_in
@@ -49,7 +49,7 @@
       If necessary, the buttons will overlap with the logo. Buttons should be on top, that's
       keep the logo here after buttons
     .header-left.header-logo-container
-      = link_to marketpace_or_landing_page_path_helper, :class => "header-logo", :id => "header-logo" do
+      = link_to root_path(locale: nil), :class => "header-logo", :id => "header-logo" do
         - if @current_community.logo.present?
           %i.header-square-logo.hidden-tablet
             -# Logo is here, it's a CSS background

--- a/app/views/layouts/_header_menu.haml
+++ b/app/views/layouts/_header_menu.haml
@@ -1,10 +1,10 @@
 #header-menu-toggle-menu.toggle-menu.header-toggle-menu-menu.hidden
 
-  = link_to marketpace_or_landing_page_path_helper do
+  = link_to root_path(locale: nil) do
     = icon_map_tag(icons, "home", ["icon-with-text"])
     = t("header.home")
 
-  = link_to(homepage_without_locale_path, class: 'hidden-tablet') do
+  = link_to(homepage_without_locale_path(locale: nil), class: 'hidden-tablet') do
     = icon_class_tag("icon-th", ["icon-with-text"])
     = t("header.marketplace")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
   }
 
   # Landing page acts as root, redirecting to marketplace if user logged in
+  root to: "marketplace_landing_page_#show"
   get '/:locale/' => 'marketplace_landing_page_#show', :constraints => { :locale => locale_matcher }, as: :marketplace_landing_page_with_locale
   get '/' => 'marketplace_landing_page#show', as: :marketplace_landing_page_without_locale
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,10 +92,16 @@ Rails.application.routes.draw do
     CustomLandingPage::LandingPageStore.enabled?(request.env[:current_marketplace]&.id)
   }
 
+  # Landing page acts as root, redirecting to marketplace if user logged in
+  get '/:locale/' => 'marketplace_landing_page_#show', :constraints => { :locale => locale_matcher }, as: :marketplace_landing_page_with_locale
+  get '/' => 'marketplace_landing_page#show', as: :marketplace_landing_page_without_locale
+
   # Default routes for homepage, these are matched if custom landing page is not in use
   # Inside this constraits are the routes that are used when request has subdomain other than www
-  get '/:locale/' => 'homepage#index', :constraints => { :locale => locale_matcher }, as: :homepage_with_locale
-  get '/' => 'homepage#index', as: :homepage_without_locale
+  get '/:locale/marketplace' => 'homepage#index', :constraints => { :locale => locale_matcher }, as: :homepage_with_locale
+  get '/marketplace' => 'homepage#index', as: :homepage_without_locale
+
+  # Search routes redirect to root
   get '/:locale/s', to: redirect('/%{locale}', status: 307), constraints: { locale: locale_matcher }
   get '/s', to: redirect('/', status: 307)
 
@@ -108,7 +114,6 @@ Rails.application.routes.draw do
   get '/not_available' => 'application#not_available', as: :community_not_available
 
   resources :communities, only: [:new, :create]
-
 
   devise_for :people, only: :omniauth_callbacks, controllers: { omniauth_callbacks: "omniauth" }
 

--- a/rails_tasks.txt
+++ b/rails_tasks.txt
@@ -129,3 +129,6 @@ sudo /etc/init.d/unicorn_sharetribe start	# Start
 
 Reverse proxy
 sudo service nginx start
+
+# Mail catcher
+mailcatcher --foreground --http-ip=0.0.0.0

--- a/spec/controllers/admin/admin_base_controller_spec.rb
+++ b/spec/controllers/admin/admin_base_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::AdminBaseController, type: :controller do
       sign_in_for_spec(person)
       get :index
       expect(response).to have_http_status(302)
-      expect(response).to redirect_to('/')
+      expect(response).to redirect_to(homepage_without_locale_path(locale: nil))
     end
 
     it "does not redirect admin" do

--- a/spec/controllers/admin/communities/topbar_controller_spec.rb
+++ b/spec/controllers/admin/communities/topbar_controller_spec.rb
@@ -55,7 +55,7 @@ describe Admin::Communities::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq true
 
       default_links = [
-        {:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1},
+        {:link=>'/', :title=>"Home", :priority=>-1},
         {:link=>"/infos/about", :title=>"About", :priority=>0},
         {:link=>"/user_feedbacks/new", :title=>"Contact us", :priority=>1},
         {:link=>"/invitations/new", :title=>"Invite new members", :priority=>2}
@@ -71,7 +71,7 @@ describe Admin::Communities::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq false
 
       links = TopbarHelper.links(community: @community, user: @user, locale_param: nil, host_with_port: "http://#{@community.ident}.lvh.me")
-      expect(links).to eq [{:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1}]
+      expect(links).to eq [{:link=>'/', :title=>"Home", :priority=>-1}]
     end
   end
 

--- a/spec/controllers/admin/communities/topbar_controller_spec.rb
+++ b/spec/controllers/admin/communities/topbar_controller_spec.rb
@@ -55,7 +55,7 @@ describe Admin::Communities::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq true
 
       default_links = [
-        {:link=>"/", :title=>"Home", :priority=>-1},
+        {:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1},
         {:link=>"/infos/about", :title=>"About", :priority=>0},
         {:link=>"/user_feedbacks/new", :title=>"Contact us", :priority=>1},
         {:link=>"/invitations/new", :title=>"Invite new members", :priority=>2}
@@ -71,7 +71,7 @@ describe Admin::Communities::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq false
 
       links = TopbarHelper.links(community: @community, user: @user, locale_param: nil, host_with_port: "http://#{@community.ident}.lvh.me")
-      expect(links).to eq [{:link=>"/", :title=>"Home", :priority=>-1}]
+      expect(links).to eq [{:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1}]
     end
   end
 

--- a/spec/controllers/admin2/design/topbar_controller_spec.rb
+++ b/spec/controllers/admin2/design/topbar_controller_spec.rb
@@ -55,7 +55,7 @@ describe Admin2::Design::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq true
 
       default_links = [
-        {:link=>"/", :title=>"Home", :priority=>-1},
+        {:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1},
         {:link=>"/infos/about", :title=>"About", :priority=>0},
         {:link=>"/user_feedbacks/new", :title=>"Contact us", :priority=>1},
         {:link=>"/invitations/new", :title=>"Invite new members", :priority=>2}
@@ -71,7 +71,7 @@ describe Admin2::Design::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq false
 
       links = TopbarHelper.links(community: @community, user: @user, locale_param: nil, host_with_port: "http://#{@community.ident}.lvh.me")
-      expect(links).to eq [{:link=>"/", :title=>"Home", :priority=>-1}]
+      expect(links).to eq [{:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1}]
     end
   end
 

--- a/spec/controllers/admin2/design/topbar_controller_spec.rb
+++ b/spec/controllers/admin2/design/topbar_controller_spec.rb
@@ -55,7 +55,7 @@ describe Admin2::Design::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq true
 
       default_links = [
-        {:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1},
+        {:link=>'/', :title=>"Home", :priority=>-1},
         {:link=>"/infos/about", :title=>"About", :priority=>0},
         {:link=>"/user_feedbacks/new", :title=>"Contact us", :priority=>1},
         {:link=>"/invitations/new", :title=>"Invite new members", :priority=>2}
@@ -71,7 +71,7 @@ describe Admin2::Design::TopbarController, type: :controller do
       expect(@community.configuration.display_invite_menu).to eq false
 
       links = TopbarHelper.links(community: @community, user: @user, locale_param: nil, host_with_port: "http://#{@community.ident}.lvh.me")
-      expect(links).to eq [{:link=>homepage_without_locale_path(locale: nil), :title=>"Home", :priority=>-1}]
+      expect(links).to eq [{:link=>'/', :title=>"Home", :priority=>-1}]
     end
   end
 

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -449,13 +449,13 @@ describe PeopleController, type: :controller do
     it 'does not show banned person' do
       community_host(community)
       get :show, params: {username: person_banned.username}
-      expect(response).to redirect_to(homepage_without_locale_path(locale: nil))
+      expect(response).to redirect_to(root_path(locale: nil))
     end
 
     it 'does not show deleted person' do
       community_host(community)
       get :show, params: {username: person_deleted.username}
-      expect(response).to redirect_to(homepage_without_locale_path(locale: nil))
+      expect(response).to redirect_to(root_path(locale: nil))
     end
 
     it "shows specific meta title and description" do

--- a/spec/controllers/people_controller_spec.rb
+++ b/spec/controllers/people_controller_spec.rb
@@ -449,13 +449,13 @@ describe PeopleController, type: :controller do
     it 'does not show banned person' do
       community_host(community)
       get :show, params: {username: person_banned.username}
-      expect(response).to redirect_to('/')
+      expect(response).to redirect_to(homepage_without_locale_path(locale: nil))
     end
 
     it 'does not show deleted person' do
       community_host(community)
       get :show, params: {username: person_deleted.username}
-      expect(response).to redirect_to('/')
+      expect(response).to redirect_to(homepage_without_locale_path(locale: nil))
     end
 
     it "shows specific meta title and description" do

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -33,7 +33,7 @@ describe SessionsController, "POST create", type: :controller do
   it "redirects back to original community's domain" do
     RequestStore.store[:clp_enabled] = false
     post :create, params: {:person  => {:login => "testpersonusername", :password => "testi"}}
-    expect(response).to redirect_to "http://#{@request.host}/"
+    expect(response).to redirect_to(homepage_without_locale_path(locale: nil))
   end
 end
 

--- a/spec/requests/hsts_spec.rb
+++ b/spec/requests/hsts_spec.rb
@@ -2,13 +2,6 @@ require "spec_helper"
 
 describe "HSTS header", type: :request do
 
-  before(:each) do
-    @community = FactoryGirl.create(:community)
-    @user = create_admin_for(@community)
-    @user.update(is_admin: true)
-    allow_any_instance_of(ApplicationController).to receive(:current_person).and_return(@user)
-  end
-
   before do
     @hsts_max_age = 10
   end

--- a/spec/requests/https_redirects_spec.rb
+++ b/spec/requests/https_redirects_spec.rb
@@ -2,13 +2,6 @@ require "spec_helper"
 
 describe "Redirect to HTTPS", type: :request do
 
-  before(:each) do
-    @community = FactoryGirl.create(:community)
-    @user = create_admin_for(@community)
-    @user.update(is_admin: true)
-    allow_any_instance_of(ApplicationController).to receive(:current_person).and_return(@user)
-  end
-
   def expect_redirect(http_url, https_url)
     get http_url
     expect(response.status).to eq 301

--- a/spec/requests/landing_pages_spec.rb
+++ b/spec/requests/landing_pages_spec.rb
@@ -107,7 +107,7 @@ describe "Landing page", type: :request do
 
   context "when not released" do
     it "index routes to homepage" do
-      expect_controller("http://#{@domain}", "homepage", "index")
+      expect_controller("http://#{@domain}", "marketplace_landing_page", "show")
     end
 
     it "search path redirects to homepage" do

--- a/spec/requests/marketpace_landing_page_requests_spec.rb
+++ b/spec/requests/marketpace_landing_page_requests_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MarketplaceLandingPageController, type: :request do
   describe 'GET /landing-page' do
     it 'successful request' do
       get('/landing-page', headers: {host: "#{@community.ident}.lvh.me"})
-      expect(request).to render_template(:show)
+      expect(response).to render_template(:show)      
     end
   end
 

--- a/spec/requests/marketpace_landing_page_requests_spec.rb
+++ b/spec/requests/marketpace_landing_page_requests_spec.rb
@@ -8,33 +8,23 @@ RSpec.describe MarketplaceLandingPageController, type: :request do
     @user.update(is_admin: true)
   end
 
-  describe 'GET /landing-page' do
-    it 'successful request' do
-      get('/landing-page', headers: {host: "#{@community.ident}.lvh.me"})
-      expect(response).to render_template(:show)      
+  describe 'GET /' do
+    it 'user not logged in' do
+      get('/', headers: {host: "#{@community.ident}.lvh.me"})
+      expect(request).to render_template(:show)      
+    end
+
+    it 'user logged in' do
+      login_user(@user)
+      get('/', headers: {host: "#{@community.ident}.lvh.me"})
+      expect(request).to redirect_to(homepage_without_locale_path)
     end
   end
 
-  describe 'user redirects' do
-    describe 'GET /' do
-      it 'user not logged in' do
-        get('/', headers: {host: "#{@community.ident}.lvh.me"})
-        expect(request).to redirect_to(landing_page_path)
-      end
-
-      it 'user logged in' do
-        login_user(@user)
-        get('/', headers: {host: "#{@community.ident}.lvh.me"})
-        expect(request).not_to redirect_to(landing_page_path)
-        expect(request).to render_template(:index)
-      end
-
-      it 'can visit homepage after visiting landing page' do
-        get('/landing-page', headers: {host: "#{@community.ident}.lvh.me"})
-        get('/', headers: {host: "#{@community.ident}.lvh.me"})
-        expect(request).not_to redirect_to(landing_page_path)
-        expect(request).to render_template(:index)
-      end
+  describe 'GET /landing-page' do
+    it 'successful request' do
+      get('/landing-page', headers: {host: "#{@community.ident}.lvh.me"})
+      expect(request).to render_template(:show)      
     end
   end
 

--- a/spec/requests/marketpace_landing_page_requests_spec.rb
+++ b/spec/requests/marketpace_landing_page_requests_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MarketplaceLandingPageController, type: :request do
   describe 'GET /' do
     it 'user not logged in' do
       get('/', headers: {host: "#{@community.ident}.lvh.me"})
-      expect(request).to render_template(:show)      
+      expect(request).to render_template(:show)
     end
 
     it 'user logged in' do
@@ -24,7 +24,7 @@ RSpec.describe MarketplaceLandingPageController, type: :request do
   describe 'GET /landing-page' do
     it 'successful request' do
       get('/landing-page', headers: {host: "#{@community.ident}.lvh.me"})
-      expect(request).to render_template(:show)      
+      expect(request).to render_template(:show)
     end
   end
 

--- a/spec/routing/people_routing_spec.rb
+++ b/spec/routing/people_routing_spec.rb
@@ -119,8 +119,8 @@ describe "routing for people", type: :routing do
   it "routes /en to home page" do
     expect(get "#{@protocol_and_host}/en").to(
       route_to({
-                 :controller => "homepage",
-                 :action => "index",
+                 :controller => "marketplace_landing_page_",
+                 :action => "show",
                  :locale => "en"
                }))
   end
@@ -128,8 +128,8 @@ describe "routing for people", type: :routing do
   it "routes /pt-BR to home page" do
     expect(get "/pt-BR").to(
       route_to({
-                 :controller => "homepage",
-                 :action => "index",
+                 :controller => "marketplace_landing_page_",
+                 :action => "show",
                  :locale => "pt-BR"
                }))
   end
@@ -137,8 +137,8 @@ describe "routing for people", type: :routing do
   it "routes / to home page" do
     expect(get "/").to(
       route_to({
-                 :controller => "homepage",
-                 :action => "index"
+                 :controller => "marketplace_landing_page_",
+                 :action => "show"
                }))
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,10 +40,7 @@ prefork = lambda {
   require "email_spec"
   require './spec/support/webmock'
   require 'sphinx_helper'
-
-  require 'timecop'
   require 'database_cleaner'
-  require 'rails-controller-testing'
 
   # Requires supporting files with custom matchers and macros, etc,
   # in ./support/ and its subdirectories.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ prefork = lambda {
 
   # This file is copied to ~/spec when you run 'ruby script/generate rspec'
   # from the project root directory.
-  ENV["RAILS_ENV"] ||= 'test'
+  ENV["RAILS_ENV"] = 'test'
   require File.expand_path('../config/environment', __dir__)
   require 'rspec/rails'
   require "email_spec"


### PR DESCRIPTION
**Task:** https://www.wrike.com/open.htm?id=298722399
**Issue:** Update redirects so users not logged in always get directed to the landing page
**Changes:**
- update rails routes to make root_path '/' select marketplace_landing_page_controller
- homepage controller route moved to '/marketplace'
- marketplace_landing_page_controller redirects to '/marketplace' if user logged in
- path helpers updated to use root_path instead of homepage_path
- update specs

**Deploy:**
- restart application server